### PR TITLE
fix: catch and log error from flag config poller request

### DIFF
--- a/packages/node/src/local/fetcher.ts
+++ b/packages/node/src/local/fetcher.ts
@@ -37,7 +37,9 @@ export class FlagConfigFetcher {
     const endpoint = `${this.serverUrl}/sdk/rules?eval_mode=local`;
     const headers = {
       Authorization: `Api-Key ${this.apiKey}`,
+      Accept: 'application/json',
       'X-Amp-Exp-Library': `experiment-node-server/${PACKAGE_VERSION}`,
+      'Content-Type': 'application/json;charset=utf-8',
     };
     const body = null;
     this.logger.debug('[Experiment] Get flag configs');

--- a/packages/node/src/local/poller.ts
+++ b/packages/node/src/local/poller.ts
@@ -49,7 +49,11 @@ export class FlagConfigPoller {
     if (!this.poller) {
       this.logger.debug('[Experiment] poller - start');
       this.poller = setInterval(async () => {
-        await this.update(onChange);
+        try {
+          await this.update(onChange);
+        } catch (e) {
+          this.logger.debug('[Experiment] flag config update failed', e);
+        }
       }, this.pollingIntervalMillis);
 
       // Fetch initial flag configs and await the result.


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

* The error getting thrown from the fetcher to the poller was not being caught, which would cause a crash. 
* Add content and type and accept headers to the poller request.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
