### PR TITLE
feat: use socket timeout as default timeout

### DIFF
--- a/packages/node/src/types/config.ts
+++ b/packages/node/src/types/config.ts
@@ -17,7 +17,7 @@ export type RemoteEvaluationConfig = {
   serverUrl?: string;
 
   /**
-   * The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
+   * The request socket timeout, in milliseconds.
    */
   fetchTimeoutMillis?: number;
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Change the timeout logic to use socket timeout instead of an internal node timeout using setTimeout.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
