### PR TITLE
fix: Auto assignment tracking insert_id timestamp round to integer

### DIFF
--- a/packages/node/src/assignment/assignment-service.ts
+++ b/packages/node/src/assignment/assignment-service.ts
@@ -57,7 +57,7 @@ export class AmplitudeAssignmentService implements AssignmentService {
 
     event.insert_id = `${event.user_id} ${event.device_id} ${hashCode(
       assignment.canonicalize(),
-    )} ${assignment.timestamp / DAY_MILLIS}`;
+    )} ${Math.floor(assignment.timestamp / DAY_MILLIS)}`;
     return event;
   }
 }

--- a/packages/node/test/local/assignment/assignment-service.test.ts
+++ b/packages/node/test/local/assignment/assignment-service.test.ts
@@ -49,9 +49,9 @@ test('assignment to event as expected', async () => {
   expect(Object.keys(userProperties['$set']).length).toEqual(1);
   expect(Object.keys(userProperties['$unset']).length).toEqual(1);
   const canonicalization = 'user device flag-key-1 on flag-key-2 control ';
-  const expected = `user device ${hashCode(canonicalization)} ${
-    assignment.timestamp / DAY_MILLIS
-  }`;
+  const expected = `user device ${hashCode(canonicalization)} ${Math.floor(
+    assignment.timestamp / DAY_MILLIS,
+  )}`;
   expect(event.insert_id).toEqual(expected);
 });
 


### PR DESCRIPTION
### Summary

Auto assignment tracking insert_id timestamp should be rounded to integer

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
