### PR TITLE
fix: don't track empty assignment events

### DIFF
--- a/packages/node/src/assignment/assignment-filter.ts
+++ b/packages/node/src/assignment/assignment-filter.ts
@@ -11,6 +11,10 @@ export class InMemoryAssignmentFilter implements AssignmentFilter {
   }
 
   public shouldTrack(assignment: Assignment): boolean {
+    if (Object.keys(assignment.results).length === 0) {
+      // Don't track empty assignments.
+      return false;
+    }
     const canonicalAssignment = assignment.canonicalize();
     const track = this.cache.get(canonicalAssignment) == undefined;
     if (track) {

--- a/packages/node/test/local/assignment/assignment-filter.test.ts
+++ b/packages/node/test/local/assignment/assignment-filter.test.ts
@@ -106,9 +106,9 @@ test('filter - empty result', async () => {
   const assignment1 = new Assignment(user1, {});
   const assignment2 = new Assignment(user1, {});
   const assignment3 = new Assignment(user2, {});
-  expect(filter.shouldTrack(assignment1)).toEqual(true);
+  expect(filter.shouldTrack(assignment1)).toEqual(false);
   expect(filter.shouldTrack(assignment2)).toEqual(false);
-  expect(filter.shouldTrack(assignment3)).toEqual(true);
+  expect(filter.shouldTrack(assignment3)).toEqual(false);
 });
 
 test('filter - duplicate assignments with different result ordering', async () => {
@@ -190,10 +190,4 @@ test('filter - ttl-based eviction', async () => {
   expect(filter.shouldTrack(assignment2)).toEqual(true);
   await sleep(950);
   expect(filter.shouldTrack(assignment2)).toEqual(false);
-});
-
-test('filter - returns false on empty assignment results', () => {
-  const filter = new InMemoryAssignmentFilter(100, 1000);
-  const emptyAssignment = new Assignment({ user_id: 'user' }, {});
-  expect(filter.shouldTrack(emptyAssignment)).toEqual(false);
 });

--- a/packages/node/test/local/assignment/assignment-filter.test.ts
+++ b/packages/node/test/local/assignment/assignment-filter.test.ts
@@ -191,3 +191,9 @@ test('filter - ttl-based eviction', async () => {
   await sleep(950);
   expect(filter.shouldTrack(assignment2)).toEqual(false);
 });
+
+test('filter - returns false on empty assignment results', () => {
+  const filter = new InMemoryAssignmentFilter(100, 1000);
+  const emptyAssignment = new Assignment({ user_id: 'user' }, {});
+  expect(filter.shouldTrack(emptyAssignment)).toEqual(false);
+});


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

dont track empty assignments

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
