### PR TITLE
fix: Amplitude Cookie should use relative imports

### DIFF
--- a/packages/node/src/cookie.ts
+++ b/packages/node/src/cookie.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger } from 'src/util/logger';
+import { ConsoleLogger } from './util/logger';
 
 import { ExperimentUser } from './types/user';
 


### PR DESCRIPTION
### Summary

Fixing an issue in 1.7.6 where the imports for logger in AmplitudeCookie fail when using the library in projects.
Fixed by using relative imports.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
