### PR TITLE
test: add stream integration test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache Node Modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
         run: git fetch --prune --unshallow --tags
 
       - name: Cache Node Modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           EU_API_KEY: ${{ secrets.EU_API_KEY }}
           EU_SECRET_KEY: ${{ secrets.EU_SECRET_KEY }}
+          MANAGEMENT_API_KEY: ${{ secrets.MANAGEMENT_API_KEY }}
 
       - name: Configure Git User
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache Node Modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: '**/node_modules'
         key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,4 @@ jobs:
         SECRET_KEY: ${{ secrets.SECRET_KEY }}
         EU_API_KEY: ${{ secrets.EU_API_KEY }}
         EU_SECRET_KEY: ${{ secrets.EU_SECRET_KEY }}
+        MANAGEMENT_API_KEY: ${{ secrets.MANAGEMENT_API_KEY }}

--- a/packages/node/test/local/stream.test.ts
+++ b/packages/node/test/local/stream.test.ts
@@ -1,0 +1,148 @@
+/* eslint-disable no-empty */
+import path from 'path';
+
+import { EvaluationFlag, SdkFlagApi } from '@amplitude/experiment-core';
+import * as dotenv from 'dotenv';
+import EventSource from 'eventsource';
+import { SdkStreamFlagApi } from 'src/local/stream-flag-api';
+import { FetchHttpClient, WrapperClient } from 'src/transport/http';
+import { StreamErrorEvent } from 'src/transport/stream';
+import { sleep } from 'src/util/time';
+
+dotenv.config({
+  path: path.join(
+    __dirname,
+    '../../',
+    process.env['ENVIRONMENT'] ? '.env.' + process.env['ENVIRONMENT'] : '.env',
+  ),
+});
+
+if (!process.env['SERVER_URL']) {
+  throw new Error(
+    'No env vars found. If running on local, have you created .env file correct environment variables? Checkout README.md',
+  );
+}
+
+const SERVER_URL = process.env['SERVER_URL'];
+const STREAM_SERVER_URL = process.env['STREAM_SERVER_URL'];
+const MANAGEMENT_API_SERVER_URL = process.env['MANAGEMENT_API_SERVER_URL'];
+const DEPLOYMENT_KEY = process.env['DEPLOYMENT_KEY'];
+const MANAGEMENT_API_KEY = process.env['MANAGEMENT_API_KEY'];
+const FLAG_KEY = 'sdk-ci-stream-flag-test';
+
+const LIBRARY = {
+  libraryName: 'experiment-node-server',
+  libraryVersion: '0.0.0',
+};
+
+// Test stream is successfully connected and data is valid.
+test('test, success', async () => {
+  const api = new SdkStreamFlagApi(
+    DEPLOYMENT_KEY,
+    STREAM_SERVER_URL,
+    (url, params) => new EventSource(url, params),
+    5000, // A bit more generous timeout than the default.
+    5000,
+    1,
+    1000000, // Very long retry delay.
+  );
+
+  const streamFlags = [];
+  let streamError = undefined;
+  const connectedPromise = new Promise<void>((resolve, reject) => {
+    api.onUpdate = (flags: Record<string, EvaluationFlag>) => {
+      streamFlags.push(flags);
+      resolve();
+    };
+    api.onError = (err: StreamErrorEvent) => {
+      streamError = err;
+      reject(err);
+    };
+    api.connect(LIBRARY).then(resolve).catch(reject);
+  });
+
+  await connectedPromise;
+
+  // Get flags from the fetch api to compare.
+  const httpClient = new FetchHttpClient(null);
+  const fetchApi = new SdkFlagApi(
+    DEPLOYMENT_KEY,
+    SERVER_URL,
+    new WrapperClient(httpClient),
+  );
+  const fetchFlags = await fetchApi.getFlags(LIBRARY);
+
+  let f = undefined;
+  while ((f = streamFlags.pop())) {
+    expect(f).toStrictEqual(fetchFlags);
+  }
+
+  // Test that stream is kept alive.
+  await sleep(20000);
+  expect(streamError).toBeUndefined();
+
+  // Test changes to flags are reflected in stream.
+  const flagVersion: number = fetchFlags[FLAG_KEY]['metadata'][
+    'flagVersion'
+  ] as number;
+
+  // Get flag id using management-api.
+  const getFlagIdRequest = await httpClient.request(
+    MANAGEMENT_API_SERVER_URL + '/api/1/flags?key=' + FLAG_KEY,
+    'GET',
+    {
+      Authorization: 'Bearer ' + MANAGEMENT_API_KEY,
+      'Content-Type': 'application/json',
+      Accept: '*/*',
+    },
+    '',
+  );
+  expect(getFlagIdRequest.status).toBe(200);
+  const flagId = JSON.parse(getFlagIdRequest.body)['flags'][0]['id'];
+
+  // Call management api to edit deployment. Then wait for stream to update.
+  while ((f = streamFlags.pop())) {}
+  let invalidation = await httpClient.request(
+    MANAGEMENT_API_SERVER_URL + '/api/1/flags/' + flagId,
+    'PATCH',
+    {
+      Authorization: 'Bearer ' + MANAGEMENT_API_KEY,
+      'Content-Type': 'application/json',
+      Accept: '*/*',
+    },
+    '{"rolloutPercentage": 50}',
+    10000,
+  );
+  expect(invalidation.status).toBe(200);
+  await sleep(5000);
+  expect(
+    streamFlags[0][FLAG_KEY]['segments'][0]['bucket']['allocations'][0][
+      'range'
+    ],
+  ).toEqual([0, 50]);
+  expect(streamFlags[0][FLAG_KEY]['metadata']['flagVersion']).toBe(
+    flagVersion + 1,
+  );
+  while ((f = streamFlags.pop())) {}
+
+  // Reset flag to original state.
+  invalidation = await httpClient.request(
+    MANAGEMENT_API_SERVER_URL + '/api/1/flags/' + flagId,
+    'PATCH',
+    {
+      Authorization: 'Bearer ' + MANAGEMENT_API_KEY,
+      'Content-Type': 'application/json',
+      Accept: '*/*',
+    },
+    '{"rolloutPercentage": 100}',
+    10000,
+  );
+  expect(invalidation.status).toBe(200);
+  await sleep(5000);
+  expect(streamFlags[0][FLAG_KEY]['segments'][0]['bucket']).toBeUndefined();
+  expect(streamFlags[0][FLAG_KEY]['metadata']['flagVersion']).toBe(
+    flagVersion + 2,
+  );
+
+  api.close();
+}, 60000);

--- a/packages/node/test/local/stream.test.ts
+++ b/packages/node/test/local/stream.test.ts
@@ -46,6 +46,7 @@ const LIBRARY = {
 // This test may be flaky if multiple edits to the flag happens simultaneously,
 // i.e. multiple invocation of this test is run at the same time.
 // If two edits are made in a very very very short period (few seconds), the first edit may not be streamed.
+jest.retryTimes(2);
 test('SDK stream is compatible with stream server (flaky possible, see comments)', async () => {
   const api = new SdkStreamFlagApi(
     DEPLOYMENT_KEY,

--- a/packages/node/test/local/stream.test.ts
+++ b/packages/node/test/local/stream.test.ts
@@ -43,7 +43,10 @@ const LIBRARY = {
 
 // Test stream is successfully connected and data is valid.
 // The main purpose is to test and ensure the SDK stream interface works with stream server.
-test('SDK stream is compatible with stream server', async () => {
+// This test may be flacky if multiple edits to the flag happens simultaneously,
+// i.e. multiple invocation of this test is run at the same time.
+// If two edits are made in a very very very short period (few seconds), the first edit may not be streamed.
+test('SDK stream is compatible with stream server (flacky possible, see comments)', async () => {
   const api = new SdkStreamFlagApi(
     DEPLOYMENT_KEY,
     STREAM_SERVER_URL,

--- a/packages/node/test/local/stream.test.ts
+++ b/packages/node/test/local/stream.test.ts
@@ -43,10 +43,10 @@ const LIBRARY = {
 
 // Test stream is successfully connected and data is valid.
 // The main purpose is to test and ensure the SDK stream interface works with stream server.
-// This test may be flacky if multiple edits to the flag happens simultaneously,
+// This test may be flaky if multiple edits to the flag happens simultaneously,
 // i.e. multiple invocation of this test is run at the same time.
 // If two edits are made in a very very very short period (few seconds), the first edit may not be streamed.
-test('SDK stream is compatible with stream server (flacky possible, see comments)', async () => {
+test('SDK stream is compatible with stream server (flaky possible, see comments)', async () => {
   const api = new SdkStreamFlagApi(
     DEPLOYMENT_KEY,
     STREAM_SERVER_URL,

--- a/packages/node/test/local/stream.test.ts
+++ b/packages/node/test/local/stream.test.ts
@@ -7,6 +7,7 @@ import EventSource from 'eventsource';
 import { SdkStreamFlagApi } from 'src/local/stream-flag-api';
 import { FetchHttpClient, WrapperClient } from 'src/transport/http';
 import { StreamErrorEvent } from 'src/transport/stream';
+import { LocalEvaluationDefaults } from 'src/types/config';
 import { sleep } from 'src/util/time';
 
 dotenv.config({
@@ -17,16 +18,21 @@ dotenv.config({
   ),
 });
 
-if (!process.env['SERVER_URL']) {
+if (!process.env['MANAGEMENT_API_KEY']) {
   throw new Error(
     'No env vars found. If running on local, have you created .env file correct environment variables? Checkout README.md',
   );
 }
 
-const SERVER_URL = process.env['SERVER_URL'];
-const STREAM_SERVER_URL = process.env['STREAM_SERVER_URL'];
-const MANAGEMENT_API_SERVER_URL = process.env['MANAGEMENT_API_SERVER_URL'];
-const DEPLOYMENT_KEY = process.env['DEPLOYMENT_KEY'];
+const SERVER_URL =
+  process.env['SERVER_URL'] || LocalEvaluationDefaults.serverUrl;
+const STREAM_SERVER_URL =
+  process.env['STREAM_SERVER_URL'] || LocalEvaluationDefaults.streamServerUrl;
+const MANAGEMENT_API_SERVER_URL =
+  process.env['MANAGEMENT_API_SERVER_URL'] ||
+  'https://experiment.amplitude.com';
+const DEPLOYMENT_KEY =
+  process.env['DEPLOYMENT_KEY'] || 'server-qz35UwzJ5akieoAdIgzM4m9MIiOLXLoz';
 const MANAGEMENT_API_KEY = process.env['MANAGEMENT_API_KEY'];
 const FLAG_KEY = 'sdk-ci-stream-flag-test';
 


### PR DESCRIPTION
### Summary

Adds an integration test for testing stream. 
The test first establish a connection, verify a flag is in the data. 
Then, it waits for keep alive to expire, ensuring keep alive is keeping connection alive. 
Then, it perform a change to the flag through management-api, and ensuring the updated flag is streamed. 
Then, it perform another change to the same flag through management-api to revert to the original state, and ensuring the updated flag is streamed. 

Our Amplitude Experiment stream service can utilize the same test, but with a different set of environment variable, to test against staging environment and ensure each deployment is compatible with all SDKs. 

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
