### PR TITLE
fix: CohortApi.getCohort() signature

### DIFF
--- a/packages/node/src/local/cohort/cohort-api.ts
+++ b/packages/node/src/local/cohort/cohort-api.ts
@@ -21,7 +21,7 @@ export interface CohortApi {
    *    throws an error if download failed.
    * @param options
    */
-  getCohort(options?: GetCohortOptions): Promise<Cohort>;
+  getCohort(options?: GetCohortOptions): Promise<Cohort | undefined>;
 }
 
 export class CohortClientRequestError extends Error {} // 4xx errors except 429


### PR DESCRIPTION
@zhukaihan Please take a look!

The implementation signature shows that it returns undefined, and the code comment/documentation indicates that it can return undefined, but the interface signature isn't showing that it returns undefined.

This results in the following error:
```
../../node_modules/@amplitude/experiment-node-server/dist/src/local/cohort/cohort-api.d.ts(34,5): error TS2416: Property 'getCohort' in type 'SdkCohortApi' is not assignable to the same property in base type 'CohortApi'.
  Type '(options?: GetCohortOptions | undefined) => Promise<Cohort | undefined>' is not assignable to type '(options?: GetCohortOptions | undefined) => Promise<Cohort>'.
    Type 'Promise<Cohort | undefined>' is not assignable to type 'Promise<Cohort>'.
      Type 'Cohort | undefined' is not assignable to type 'Cohort'.
        Type 'undefined' is not assignable to type 'Cohort'.
          Type 'undefined' is not assignable to type 'CohortDescription'.
```

### Summary

Fixes the API signature for getCohort()