### PR TITLE
fix: export logging libs

### DIFF
--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -19,6 +19,8 @@ export { ExperimentUser } from './types/user';
 export { Variant, Variants } from './types/variant';
 export { LocalEvaluationClient } from './local/client';
 export { LocalEvaluationConfig, AssignmentConfig } from './types/config';
+export { LogLevel } from './types/loglevel';
+export { LoggerProvider } from './util/logger';
 export { FlagConfigFetcher } from './local/fetcher';
 export { FlagConfigPoller } from './local/poller';
 export { InMemoryFlagConfigCache } from './local/cache';

--- a/packages/node/src/remote/client.ts
+++ b/packages/node/src/remote/client.ts
@@ -3,7 +3,6 @@ import {
   FetchError,
   SdkEvaluationApi,
 } from '@amplitude/experiment-core';
-import { AmplitudeLogger } from 'src/util/logger';
 
 import { version as PACKAGE_VERSION } from '../../gen/version';
 import { FetchHttpClient, WrapperClient } from '../transport/http';
@@ -12,6 +11,7 @@ import { FetchOptions } from '../types/fetch';
 import { ExperimentUser } from '../types/user';
 import { Variant, Variants } from '../types/variant';
 import { populateRemoteConfigDefaults } from '../util/config';
+import { AmplitudeLogger } from '../util/logger';
 import { sleep } from '../util/time';
 import {
   evaluationVariantsToVariants,


### PR DESCRIPTION
### Summary

Properly expose the new logging libs needed for log level and custom logging configuration.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
