### PR TITLE
fix: node resolution paths starting with `src/` don't work

### DIFF
--- a/packages/node/src/exposure/exposure-service.ts
+++ b/packages/node/src/exposure/exposure-service.ts
@@ -1,4 +1,5 @@
 import { BaseEvent, CoreClient } from '@amplitude/analytics-types';
+
 import { hashCode } from '../util/hash';
 
 import { Exposure, ExposureFilter, ExposureService } from './exposure';

--- a/packages/node/src/exposure/exposure.ts
+++ b/packages/node/src/exposure/exposure.ts
@@ -1,4 +1,5 @@
 import { EvaluationVariant } from '@amplitude/experiment-core';
+
 import { ExperimentUser } from '../types/user';
 
 export interface ExposureService {

--- a/packages/node/src/local/client.ts
+++ b/packages/node/src/local/client.ts
@@ -5,13 +5,13 @@ import {
   topologicalSort,
 } from '@amplitude/experiment-core';
 import EventSource from 'eventsource';
-import { Exposure, ExposureService } from '../exposure/exposure';
-import { InMemoryExposureFilter } from '../exposure/exposure-filter';
-import { AmplitudeExposureService } from '../exposure/exposure-service';
 
 import { Assignment, AssignmentService } from '../assignment/assignment';
 import { InMemoryAssignmentFilter } from '../assignment/assignment-filter';
 import { AmplitudeAssignmentService } from '../assignment/assignment-service';
+import { Exposure, ExposureService } from '../exposure/exposure';
+import { InMemoryExposureFilter } from '../exposure/exposure-filter';
+import { AmplitudeExposureService } from '../exposure/exposure-service';
 import { FetchHttpClient } from '../transport/http';
 import { StreamEventSourceFactory } from '../transport/stream';
 import { USER_GROUP_TYPE } from '../types/cohort';

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -7,6 +7,7 @@
     "rootDir": ".",
     "baseUrl": ".",
     "paths": {
+      "src/*": ["./src/*"],
       "test/*": ["./test/*"]
     }
   },


### PR DESCRIPTION
These TypeScript alias paths are not converted by tsc to relative imports. Either use a postprocessor like `tsc-alias` that converts those aliased path, or don't use them to begin with.

I opted in this PR with the option that doesn't add a dependency.

Fixes https://github.com/amplitude/experiment-node-server/issues/62
