### PR TITLE
fix: replace remaining console log output with this.logger

### DIFF
--- a/packages/node/src/remote/client.ts
+++ b/packages/node/src/remote/client.ts
@@ -72,12 +72,12 @@ export class RemoteEvaluationClient {
     try {
       return await this.doFetch(user, this.config.fetchTimeoutMillis, options);
     } catch (e) {
-      console.error('[Experiment] Fetch failed: ', e);
+      this.logger.error('[Experiment] Fetch failed: ', e);
       if (this.shouldRetryFetch(e)) {
         try {
           return await this.retryFetch(user, options, e);
         } catch (e) {
-          console.error(e);
+          this.logger.error(e);
         }
       }
       throw e;
@@ -103,7 +103,7 @@ export class RemoteEvaluationClient {
       const results = await this.fetchV2(user, options);
       return filterDefaultVariants(results);
     } catch (e) {
-      console.error('[Experiment] Failed to fetch variants: ', e);
+      this.logger.error('[Experiment] Failed to fetch variants: ', e);
       return {};
     }
   }
@@ -151,7 +151,7 @@ export class RemoteEvaluationClient {
           options,
         );
       } catch (e) {
-        console.error('[Experiment] Retry falied: ', e);
+        this.logger.error('[Experiment] Retry falied: ', e);
         err = e;
       }
       delayMillis = Math.min(


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Replaces a few remaining console.* log outputs with this.logger so that logger provider is used everywhere.

### Checklist

* [ x ] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
