### PR TITLE
fix: bump experiment-core to 0.13.1 for local eval bugfix

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@amplitude/analytics-node": "^1.3.4",
     "@amplitude/analytics-types": "^1.3.1",
-    "@amplitude/experiment-core": "0.12.0",
+    "@amplitude/experiment-core": "0.13.1",
     "eventsource": "^2.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,10 +36,10 @@
   resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-1.3.3.tgz#c7b2a21e6ab0eb1670cce4d03127b62c373c6ed4"
   integrity sha512-V4/h+izhG7NyVfIva1uhe6bToI/l5n+UnEomL3KEO9DkFoKiOG7KmXo/fmzfU6UmD1bUEWmy//hUFF16BfrEww==
 
-"@amplitude/experiment-core@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.12.0.tgz#9a2ee4c054da6dd629bbabbcbbf20188cdece3dd"
-  integrity sha512-EiLLxcyJD8T3GFsMPxBfWx9n9fBw6rC0RJwccPXLzResE0HnGZZpVWF86ZndnYmEMD1lUUjWi41N1ymEzodI5w==
+"@amplitude/experiment-core@0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/experiment-core/-/experiment-core-0.13.1.tgz#660dc3952626af0138ff12eb4d161fa63869ad9c"
+  integrity sha512-ZHvR0dxTltasp8MiMcQ6qKsY20mWnODoy3oebGad6qaRR1ywpUi8IuLf5AwLTM35ZwgzEUTn9TEIWKLHpDwHMw==
   dependencies:
     js-base64 "^3.7.5"
 


### PR DESCRIPTION
## Summary
- Bumps `@amplitude/experiment-core` from `0.12.0` to `0.13.1` to pick up a local evaluation bugfix.

## Test plan
- [ ] CI passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; behavior changes are confined to whatever `@amplitude/experiment-core` modifies (notably local evaluation), so regressions would come from the upstream release.
> 
> **Overview**
> Updates the Node server SDK dependency on `@amplitude/experiment-core` from `0.12.0` to `0.13.1`.
> 
> Refreshes `yarn.lock` to pin the new `experiment-core` tarball and integrity, with no other code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a317191ae8a45c76018803891cd2c7a22a0ca58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->