### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/packages/node/src/exposure/exposure-service.ts
+++ b/packages/node/src/exposure/exposure-service.ts
@@ -66,6 +66,10 @@ export const toExposureEvents = (
     } else if (variant.value) {
       eventProperties['[Experiment] Variant'] = variant.value;
     }
+    const experimentKey = variant.metadata?.experimentKey as string | undefined;
+    if (experimentKey) {
+      eventProperties['[Experiment] Experiment Key'] = experimentKey;
+    }
     if (variant.metadata) {
       eventProperties['metadata'] = variant.metadata;
     }

--- a/packages/node/test/local/exposure/exposure-service.test.ts
+++ b/packages/node/test/local/exposure/exposure-service.test.ts
@@ -84,10 +84,21 @@ test('exposure to event as expected', async () => {
       value: 'on',
     },
     empty_variant: {},
+    with_experiment_key: {
+      key: 'treatment',
+      value: 'treatment',
+      metadata: {
+        segmentName: 'All Other Users',
+        flagType: 'experiment',
+        flagVersion: 10,
+        default: false,
+        experimentKey: 'exp-1',
+      },
+    },
   };
   const exposure = new Exposure(user, results);
   const events = toExposureEvents(exposure, DAY_MILLIS);
-  expect(events.length).toEqual(7); // Excludes default exposure.
+  expect(events.length).toEqual(8); // Excludes default exposure.
   for (const event of events) {
     expect(event.user_id).toEqual(user.user_id);
     expect(event.device_id).toEqual(user.device_id);
@@ -103,6 +114,12 @@ test('exposure to event as expected', async () => {
       results[flagKey].key,
     );
     expect(eventProperties['metadata']).toEqual(results[flagKey].metadata);
+
+    if (flagKey === 'with_experiment_key') {
+      expect(eventProperties['[Experiment] Experiment Key']).toEqual('exp-1');
+    } else {
+      expect(eventProperties['[Experiment] Experiment Key']).toBeUndefined();
+    }
 
     // User Properties
     if (
@@ -125,7 +142,7 @@ test('exposure to event as expected', async () => {
     }
 
     const canonicalization =
-      'user device basic control default off different_value on empty_metadata on holdout holdout mutex slot-1 partial_metadata on ';
+      'user device basic control default off different_value on empty_metadata on holdout holdout mutex slot-1 partial_metadata on with_experiment_key treatment ';
     const expected = `user device ${hashCode(
       flagKey + ' ' + canonicalization,
     )} ${Math.floor(exposure.timestamp / DAY_MILLIS)}`;


### PR DESCRIPTION
## Summary

- Local evaluation via `evaluateV2` was emitting exposure events that included the variant metadata blob (containing `metadata.experimentKey`) but never lifted the experiment key onto a top-level event property. Custom reports that key off `[Experiment] Experiment Key` therefore saw no value for customers on local evaluation.
- Fix: in `toExposureEvents`, when `variant.metadata?.experimentKey` is truthy, set `event_properties['[Experiment] Experiment Key']`. Additive and backwards-compatible — the existing `metadata` blob, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `insert_id` are unchanged.
- Mirrors the equivalent behavior in the browser SDK (`experiment-js-client/.../experimentClient.ts` sets `exposure.experiment_key = sourceVariant.variant?.expKey`). Property name uses the bracketed-namespace convention already established in this file (`[Experiment] Flag Key`, `[Experiment] Variant`) rather than the browser SDK's snake_case, since the browser SDK emits via a typed `Exposure` object that gets translated downstream, whereas this file emits Amplitude events directly.

## Test plan

- [x] Added `with_experiment_key` fixture to the existing `toExposureEvents` test in `packages/node/test/local/exposure/exposure-service.test.ts`. Asserts the new property equals `'exp-1'` for that flag and is `undefined` for all other flags in the same exposure.
- [x] Updated the canonicalization expectation in the same test to account for the new fixture entry (`with_experiment_key treatment` appended in alphabetical order).
- [x] `yarn workspace @amplitude/experiment-node-server test` — 208 passed, 1 todo, 0 failures.
- [x] `yarn workspace @amplitude/experiment-node-server lint` — 0 errors (19 pre-existing warnings, none from this change).
- [x] `yarn workspace @amplitude/experiment-node-server build` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change that only adds an extra event property when `variant.metadata.experimentKey` is present; main risk is minor downstream analytics/reporting impact from a new field.
> 
> **Overview**
> Local-eval exposure events now lift `variant.metadata.experimentKey` into a top-level event property (`event_properties['[Experiment] Experiment Key']`) when present, aligning exposure reporting with other SDKs.
> 
> Tests extend the `toExposureEvents` fixture to include a flag with an `experimentKey`, assert the new property is set only for that flag, and update expected event count and `insert_id` canonicalization accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23e16845969c1d61af08015f048e8668befb8be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->